### PR TITLE
Graceful Shutdown

### DIFF
--- a/src/main/java/net/centro/rtb/monitoringcenter/MonitoringCenter.java
+++ b/src/main/java/net/centro/rtb/monitoringcenter/MonitoringCenter.java
@@ -626,6 +626,7 @@ public class MonitoringCenter {
             MoreExecutors.shutdownAndAwaitTermination(executorService, 1, TimeUnit.SECONDS);
         }
 
+        graphiteReporter.report();
         if (graphiteReporter != null) {
             graphiteReporter.stop();
         }

--- a/src/main/java/net/centro/rtb/monitoringcenter/MonitoringCenter.java
+++ b/src/main/java/net/centro/rtb/monitoringcenter/MonitoringCenter.java
@@ -626,8 +626,8 @@ public class MonitoringCenter {
             MoreExecutors.shutdownAndAwaitTermination(executorService, 1, TimeUnit.SECONDS);
         }
 
-        graphiteReporter.report();
         if (graphiteReporter != null) {
+            graphiteReporter.report();
             graphiteReporter.stop();
         }
 


### PR DESCRIPTION
Updating shutdown method to call graphiteReport.report before stopping it.  This will flush all the remaining metrics