### PR TITLE
Updating the version of drop wizard metrics library to 3.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <javac.target.version>1.8</javac.target.version>
 
         <jackson.version>2.9.0</jackson.version>
-        <metrics.version>3.2.2</metrics.version>
+        <metrics.version>3.2.6</metrics.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Updating the version of dropwizard metrics library. The current version being used is about 2.5 years old. Furthermore following fixes/improvements make the update necessary/desirable : 

- SlidingTimeWindowArrayReservoir as a fast alternative of SlidingTimeWindowReservoir (Required by your truly)
- ExponentiallyDecayingReservoir was giving incorrect values in the snapshot if the inactive period was too long
- Fix GraphiteReporter rate reporting 
- [InstrumentedScheduledExecutorService] Fix the scheduledFixedDelay to call the correct method 

ref : https://metrics.dropwizard.io/4.1.0/about/release-notes.html#v3-2-6-dec-24-2017

